### PR TITLE
Remove parenthesis around single parameter

### DIFF
--- a/ch03.md
+++ b/ch03.md
@@ -37,7 +37,7 @@ const minimum = 21;
 const checkAge = age => age >= minimum;
 
 // pure
-const checkAge = (age) => {
+const checkAge = age => {
   const minimum = 21;
   return age >= minimum;
 };
@@ -154,7 +154,7 @@ squareNumber(5); // 25, returns cache for input 5
 Here is a simplified implementation, though there are plenty of more robust versions available.
 
 ```js
-const memoize = (f) => {
+const memoize = f => {
   const cache = {};
 
   return (...args) => {
@@ -183,13 +183,13 @@ Pure functions are completely self contained. Everything the function needs is h
 
 ```js
 // impure
-const signUp = (attrs) => {
+const signUp = attrs => {
   const user = saveUser(attrs);
   welcomeUser(user);
 };
 
 // pure
-const signUp = (Db, Email, attrs) => (_) => {
+const signUp = (Db, Email, attrs) => _ => {
   const user = saveUser(Db, attrs);
   welcomeUser(Email, user);
 };

--- a/ch05.md
+++ b/ch05.md
@@ -56,7 +56,7 @@ compose(compose(toUpperCase, head), reverse);
 Since it doesn't matter how we group our calls to `compose`, the result will be the same. That allows us to write a variadic compose and use it as follows:
 
 ```js
-// previously we'd have to write two composes, but since it's associative, 
+// previously we'd have to write two composes, but since it's associative,
 // we can give compose as many fn's as we like and let it decide how to group them.
 const arg = ['jumpkick', 'roundhouse', 'uppercut'];
 const lastUpper = compose(toUpperCase, head, reverse);
@@ -271,21 +271,21 @@ In each following exercise, we'll consider Car objects with the following shape:
 ```
 
 
-{% exercise %}  
-Use `compose()` to rewrite the function below.  
-  
-{% initial src="./exercises/ch05/exercise_a.js#L12;" %}  
-```js  
-const isLastInStock = (cars) => {  
-  const lastCar = last(cars);  
-  return prop('in_stock', lastCar);  
-};  
-```  
-  
-{% solution src="./exercises/ch05/solution_a.js" %}  
-{% validation src="./exercises/ch05/validation_a.js" %}  
-{% context src="./exercises/support.js" %}  
-{% endexercise %}  
+{% exercise %}
+Use `compose()` to rewrite the function below.
+
+{% initial src="./exercises/ch05/exercise_a.js#L12;" %}
+```js
+const isLastInStock = cars => {
+  const lastCar = last(cars);
+  return prop('in_stock', lastCar);
+};
+```
+
+{% solution src="./exercises/ch05/solution_a.js" %}
+{% validation src="./exercises/ch05/validation_a.js" %}
+{% context src="./exercises/support.js" %}
+{% endexercise %}
 
 
 ---
@@ -297,43 +297,43 @@ Considering the following function:
 const average = xs => reduce(add, 0, xs) / xs.length;
 ```
 
-{% exercise %}  
-Use the helper function `average` to refactor `averageDollarValue` as a composition.  
-  
-{% initial src="./exercises/ch05/exercise_b.js#L7;" %}  
-```js  
-const averageDollarValue = (cars) => {  
-  const dollarValues = map(c => c.dollar_value, cars);  
-  return average(dollarValues);  
-};  
-```  
-  
-{% solution src="./exercises/ch05/solution_b.js" %}  
-{% validation src="./exercises/ch05/validation_b.js" %}  
-{% context src="./exercises/support.js" %}  
-{% endexercise %}  
+{% exercise %}
+Use the helper function `average` to refactor `averageDollarValue` as a composition.
+
+{% initial src="./exercises/ch05/exercise_b.js#L7;" %}
+```js
+const averageDollarValue = cars => {
+  const dollarValues = map(c => c.dollar_value, cars);
+  return average(dollarValues);
+};
+```
+
+{% solution src="./exercises/ch05/solution_b.js" %}
+{% validation src="./exercises/ch05/validation_b.js" %}
+{% context src="./exercises/support.js" %}
+{% endexercise %}
 
 
 ---
 
 
-{% exercise %}  
-Refactor `fastestCar` using `compose()` and other functions in pointfree-style. Hint, the  
-`flip` function may come in handy.  
-  
-{% initial src="./exercises/ch05/exercise_c.js#L4;" %}  
-```js  
-const fastestCar = (cars) => {  
-  const sorted = sortBy(car => car.horsepower);  
-  const fastest = last(sorted);  
-  return concat(fastest.name, ' is the fastest');  
-};  
-```  
-  
-{% solution src="./exercises/ch05/solution_c.js" %}  
-{% validation src="./exercises/ch05/validation_c.js" %}  
-{% context src="./exercises/support.js" %}  
-{% endexercise %}  
+{% exercise %}
+Refactor `fastestCar` using `compose()` and other functions in pointfree-style. Hint, the
+`flip` function may come in handy.
+
+{% initial src="./exercises/ch05/exercise_c.js#L4;" %}
+```js
+const fastestCar = cars => {
+  const sorted = sortBy(car => car.horsepower);
+  const fastest = last(sorted);
+  return concat(fastest.name, ' is the fastest');
+};
+```
+
+{% solution src="./exercises/ch05/solution_c.js" %}
+{% validation src="./exercises/ch05/validation_c.js" %}
+{% context src="./exercises/support.js" %}
+{% endexercise %}
 
 [lodash-website]: https://lodash.com/
 [underscore-website]: http://underscorejs.org/

--- a/ch06.md
+++ b/ch06.md
@@ -33,7 +33,7 @@ Here is another example.
 
 ```js
 // imperative
-const authenticate = (form) => {
+const authenticate = form => {
   const user = toUser(form);
   return logIn(user);
 };

--- a/ch09.md
+++ b/ch09.md
@@ -44,7 +44,7 @@ const fs = require('fs');
 const readFile = filename => new IO(_ => fs.readFileSync(filename, 'utf-8'));
 
 // print :: String -> IO String
-const print = x => new IO((_) => {
+const print = x => new IO(_ => {
   console.log(x);
   return x;
 });
@@ -159,7 +159,7 @@ Again, we simply remove one layer. Mind you, we have not thrown out purity, but 
 
 ```js
 // log :: a -> IO a
-const log = x => IO.of((_) => {
+const log = x => IO.of(_ => {
   console.log(x);
   return x;
 });
@@ -281,7 +281,7 @@ querySelector('input.username').chain(({ value: uname }) =>
 
 Finally, we have two examples using `Maybe`. Since `chain` is mapping under the hood, if any value is `null`, we stop the computation dead in its tracks.
 
-Don't worry if these examples are hard to grasp at first. Play with them. Poke them with a stick. Smash them to bits and reassemble. Remember to `map` when returning a "normal" value and `chain` when we're returning another functor. In the next chapter, we'll approach `Applicatives` and see nice tricks to make this kind of expressions nicer and highly readable. 
+Don't worry if these examples are hard to grasp at first. Play with them. Poke them with a stick. Smash them to bits and reassemble. Remember to `map` when returning a "normal" value and `chain` when we're returning another functor. In the next chapter, we'll approach `Applicatives` and see nice tricks to make this kind of expressions nicer and highly readable.
 
 As a reminder, this does not work with two different nested types. Functor composition and later, monad transformers, can help us in that situation.
 
@@ -389,33 +389,33 @@ In the next chapter, we'll see how applicative functors fit into the container w
 
 Condering a User object as follow:
 
-```js  
-const user = {  
-  id: 1,  
-  name: 'Albert',  
-  address: {  
-    street: {  
-      number: 22,  
-      name: 'Walnut St',  
-    },  
-  },  
-};  
-```  
-  
-{% exercise %}  
-Use `safeProp` and `map/join` or `chain` to safely get the street name when given a user  
-  
-{% initial src="./exercises/ch09/exercise_a.js#L16;" %}  
-```js  
-// getStreetName :: User -> Maybe String  
-const getStreetName = undefined;  
-```  
-  
-  
-{% solution src="./exercises/ch09/solution_a.js" %}  
-{% validation src="./exercises/ch09/validation_a.js" %}  
-{% context src="./exercises/support.js" %}  
-{% endexercise %}  
+```js
+const user = {
+  id: 1,
+  name: 'Albert',
+  address: {
+    street: {
+      number: 22,
+      name: 'Walnut St',
+    },
+  },
+};
+```
+
+{% exercise %}
+Use `safeProp` and `map/join` or `chain` to safely get the street name when given a user
+
+{% initial src="./exercises/ch09/exercise_a.js#L16;" %}
+```js
+// getStreetName :: User -> Maybe String
+const getStreetName = undefined;
+```
+
+
+{% solution src="./exercises/ch09/solution_a.js" %}
+{% validation src="./exercises/ch09/validation_a.js" %}
+{% context src="./exercises/support.js" %}
+{% endexercise %}
 
 
 ---
@@ -431,23 +431,23 @@ const getFile = () => IO.of('/home/mostly-adequate/ch9.md');
 const pureLog = str => new IO(() => console.log(str));
 ```
 
-{% exercise %}  
-Use getFile to get the filepath, remove the directory and keep only the basename,  
-then purely log it. Hint: you may want to use `split` and `last` to obtain the  
-basename from a filepath.  
-  
-{% initial src="./exercises/ch09/exercise_b.js#L13;" %}  
-```js  
-// logFilename :: IO ()  
-const logFilename = undefined;  
-  
-```  
-  
-  
-{% solution src="./exercises/ch09/solution_b.js" %}  
-{% validation src="./exercises/ch09/validation_b.js" %}  
-{% context src="./exercises/support.js" %}  
-{% endexercise %}  
+{% exercise %}
+Use getFile to get the filepath, remove the directory and keep only the basename,
+then purely log it. Hint: you may want to use `split` and `last` to obtain the
+basename from a filepath.
+
+{% initial src="./exercises/ch09/exercise_b.js#L13;" %}
+```js
+// logFilename :: IO ()
+const logFilename = undefined;
+
+```
+
+
+{% solution src="./exercises/ch09/solution_b.js" %}
+{% validation src="./exercises/ch09/validation_b.js" %}
+{% context src="./exercises/support.js" %}
+{% endexercise %}
 
 
 ---
@@ -460,19 +460,19 @@ For this exercise, we consider helpers with the following signatures:
 // emailBlast :: [Email] -> IO ()
 ```
 
-{% exercise %}  
-Use `validateEmail`, `addToMailingList` and `emailBlast` to create a function  
-which adds a new email to the mailing list if valid, and then notify the whole  
-list.  
-  
-{% initial src="./exercises/ch09/exercise_c.js#L11;" %}  
-```js  
-// joinMailingList :: Email -> Either String (IO ())  
-const joinMailingList = undefined;  
-```  
-  
-  
-{% solution src="./exercises/ch09/solution_c.js" %}  
-{% validation src="./exercises/ch09/validation_c.js" %}  
-{% context src="./exercises/support.js" %}  
-{% endexercise %}  
+{% exercise %}
+Use `validateEmail`, `addToMailingList` and `emailBlast` to create a function
+which adds a new email to the mailing list if valid, and then notify the whole
+list.
+
+{% initial src="./exercises/ch09/exercise_c.js#L11;" %}
+```js
+// joinMailingList :: Email -> Either String (IO ())
+const joinMailingList = undefined;
+```
+
+
+{% solution src="./exercises/ch09/solution_c.js" %}
+{% validation src="./exercises/ch09/validation_c.js" %}
+{% context src="./exercises/support.js" %}
+{% endexercise %}

--- a/exercises/ch05/exercise_a.js
+++ b/exercises/ch05/exercise_a.js
@@ -11,7 +11,7 @@
 
 
 // isLastInStock :: [Car] -> Boolean
-const isLastInStock = (cars) => {
+const isLastInStock = cars => {
   const lastCar = last(cars);
   return prop('in_stock', lastCar);
 };

--- a/exercises/ch05/exercise_b.js
+++ b/exercises/ch05/exercise_b.js
@@ -5,7 +5,7 @@
 // Use the helper function `average` to refactor `averageDollarValue` as a composition.
 
 // averageDollarValue :: [Car] -> Int
-const averageDollarValue = (cars) => {
+const averageDollarValue = cars => {
   const dollarValues = map(c => c.dollar_value, cars);
   return average(dollarValues);
 };

--- a/exercises/ch05/exercise_c.js
+++ b/exercises/ch05/exercise_c.js
@@ -2,7 +2,7 @@
 // Hint, the `flip` function may come in handy.
 
 // fastestCar :: [Car] -> String
-const fastestCar = (cars) => {
+const fastestCar = cars => {
   const sorted = sortBy(car => car.horsepower, cars);
   const fastest = last(sorted);
   return concat(fastest.name, ' is the fastest');

--- a/exercises/ch09/validation_a.js
+++ b/exercises/ch09/validation_a.js
@@ -3,13 +3,13 @@
 const res = getStreetName(albert);
 
 if ((!(res instanceof Maybe) || typeof res.$value !== 'string' || res.isNothing) && getStreetName.callees) {
-  [1, 2, 3].forEach((i) => {
+  [1, 2, 3].forEach(i => {
     if (getStreetName.callees[i] === 'map' && getStreetName.callees[i + 1] !== 'join') {
       throw new Error('The function gives incorrect results; hint: you can use `join` to flatten two monads!');
     }
   });
 
-  [1, 2].forEach((i) => {
+  [1, 2].forEach(i => {
     if (!['map', 'chain'].includes(getStreetName.callees[i])) {
       throw new Error('The function gives incorrect results; hint: look carefully at the signature of `safeProp` and `chain`!');
     }

--- a/exercises/ch11/validation_b.js
+++ b/exercises/ch11/validation_b.js
@@ -11,7 +11,7 @@ assert(
   'The function has an incorrect type; hint: `findNameById` must return a `Task String User`!',
 );
 
-res.fork(throwUnexpected, (val) => {
+res.fork(throwUnexpected, val => {
   assert(
     !(val instanceof Task),
     'The function has an incorrect type; hint: `findNameById` must return a `Task String User`, make sure to flatten any nested Functor!',
@@ -36,7 +36,7 @@ assert(
   'The function has an incorrect type; hint: `findNameById` must return a `Task String User`!',
 );
 
-rej.fork((val) => {
+rej.fork(val => {
   assert(
     !(val instanceof Task),
     'The function has an incorrect type; hint: `findNameById` must return a `Task String User`, make sure to flatten any nested Functor!',

--- a/exercises/ch12/validation_a.js
+++ b/exercises/ch12/validation_a.js
@@ -11,7 +11,7 @@ assert(
   'The function has an invalid type; hint: `getJsons` must return a `Task`!',
 );
 
-res.fork(throwUnexpected, ($res) => {
+res.fork(throwUnexpected, $res => {
   assert(
     $res.$value['/'] === 'json for /' && $res.$value['/about'] === 'json for /about',
     'The function gives incorrect results; hint: did you correctly map `httpGet` over the Map\'s values?',

--- a/exercises/ch12/validation_c.js
+++ b/exercises/ch12/validation_c.js
@@ -11,7 +11,7 @@ assert(
   'The function has an invalid type; hint: `readFirst` must return a `Task`!',
 );
 
-res.fork(throwUnexpected, ($res) => {
+res.fork(throwUnexpected, $res => {
   assert(
     $res instanceof Maybe,
     'The function has an invalid type; hint: `readFirst` must return a `Task Error (Maybe String)`!',

--- a/exercises/support.js
+++ b/exercises/support.js
@@ -91,7 +91,7 @@ const typeMismatch = (src, got, fn) => `Type Mismatch in function '${fn}'
 const capitalize = s => `${s[0].toUpperCase()}${s.substring(1)}`;
 
 
-const ordinal = (i) => {
+const ordinal = i => {
   switch (i) {
     case 1:
       return '1st';
@@ -104,7 +104,7 @@ const ordinal = (i) => {
   }
 };
 
-const getType = (x) => {
+const getType = x => {
   if (x === null) {
     return 'Null';
   }

--- a/exercises/test-utils.js
+++ b/exercises/test-utils.js
@@ -40,7 +40,7 @@ const readExercises = (ch, sections = ['exercise', 'solution', 'validation']) =>
   const folder = path.join(__dirname, ch);
 
   const partition = reduce((pts, f) => {
-    forEach((section) => {
+    forEach(section => {
       const re = filenameRe(section);
 
       if (re.test(f)) {


### PR DESCRIPTION
To make the style more consistent, since the parentheses are left out in most similar cases in this document.